### PR TITLE
Validation des adresses email des mairies

### DIFF
--- a/lib/publication/models.js
+++ b/lib/publication/models.js
@@ -26,11 +26,11 @@ const getCommuneEmail = async function (codeCommune) {
       .filter(m => !normalize(m.properties.nom).includes('deleguee'))[0]
 
     const {email} = mairie.properties
-    if (validateEmail(mairie.properties.email)) {
+    if (validateEmail(email)) {
       return email
     }
 
-    throw new Error(`L’adresse email " ${email} " ne pas pas être utilisée`)
+    throw new Error(`L’adresse email " ${email} " ne peut pas être utilisée`)
   } catch (error) {
     console.log(`Une erreur s’est produite lors de la récupération de l’adresse email de la mairie : ${error}`)
   }


### PR DESCRIPTION
## Contexte
Certaine mairie dispose d'une URL à la place d'une adresse email pour les contacter. Ce qui empêche l'envoi d'un code d'authentification alors que cette option est proposée car le champ `email` est renseigné.

## Évolution
Ajout d'une étape de validation qui s'assure que l'adresse de contact renseigné est bien une adresse email valide. 