### PR TITLE
Ajout d'un message d'erreur lorsque l'adresse email d'une commune est undefined

### DIFF
--- a/lib/publication/models.js
+++ b/lib/publication/models.js
@@ -23,9 +23,9 @@ const getCommuneEmail = async function (codeCommune) {
   try {
     const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {responseType: 'json'})
     const mairie = response.body.features
-      .filter(m => !normalize(m.properties.nom).includes('deleguee'))[0]
+      .find(m => !normalize(m.properties.nom).includes('deleguee'))
 
-    const {email} = mairie.properties
+    const {email} = mairie ? mairie.properties : {}
     if (!email) {
       throw new Error(`Aucune adresse email n’a pu être trouvée pour cette commune (${codeCommune})`)
     }


### PR DESCRIPTION
Plusieurs erreurs `Une erreur s’est produite lors de la récupération de l’adresse email de la mairie : Error: L’adresse email ” undefined ” ne peut pas être utilisée` sont survenues récemment.

L'ajout d'un message d'erreur dans le cas où une adresse email est `undefined` permettrait d'identifier la commune concernée.